### PR TITLE
Added fire_hydrant diameter

### DIFF
--- a/Resources/Optional.json
+++ b/Resources/Optional.json
@@ -1015,5 +1015,11 @@
       "Voodoo" : "voodoo"
     },
     "section" : "Other"
+  },
+  "fire_hydrant:diameter" : {
+    "displayName" : "Diameter",
+    "osmKey" : "fire_hydrant:diameter",
+    "values" : "number",
+    "section" : "Other"
   }
 }


### PR DESCRIPTION
I still need a 'ref' field for fire_hydrant for the number of the hydrant. How can I get one? http://wiki.openstreetmap.org/wiki/Tag:emergency%3Dfire_hydrant
